### PR TITLE
vim: go plugin追加,PATH修正

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -933,6 +933,7 @@ NeoBundle 'yuroyoro/vim-scala'
 " golang
 NeoBundle 'google/vim-ft-go'
 " NeoBundle 'dgryski/vim-godef' "vim-ft-goは最新版のvimを使えない場合のみ
+NeoBundle 'fatih/vim-go'
 NeoBundle 'vim-jp/vim-go-extra'
 
 " clojure

--- a/.zshrc.osx
+++ b/.zshrc.osx
@@ -136,7 +136,7 @@ export GOROOT=/usr/local/opt/go/libexec
 export GOPATH=$HOME/dev/go
 export GOOS=darwin
 export GOARCH=amd64
-export PATH=$PATH:$GOROOT/bin
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 # Node.js
 #[[ -s ~/.nvm/nvm.sh ]] && . ~/.nvm/nvm.sh # This loads NVM


### PR DESCRIPTION
・vim プラグイン追加
・goimports等のコマンドが使えないのでPATH追加